### PR TITLE
Error handler on failed worker

### DIFF
--- a/server/ReloadedBackendOnFailedWorkerEvent.js
+++ b/server/ReloadedBackendOnFailedWorkerEvent.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const cluster = require('cluster');
+const { Event } = require('@cuties/cutie');
+const { ForkedWorker } = require('@cuties/cluster');
+
+class ReloadedBackendOnFailedWorkerEvent extends Event {
+
+  constructor() {
+    super();
+  }
+
+  definedBody(worker, code, signal) {
+    console.log(`worker ${worker.process.pid} died (${signal || code}). restarting...`);
+    new ForkedWorker(cluster).call();
+  }
+
+}
+
+module.exports = ReloadedBackendOnFailedWorkerEvent;

--- a/server/server.js
+++ b/server/server.js
@@ -3,7 +3,8 @@
 const cluster = require('cluster');
 const { as } = require('@cuties/cutie');
 const { If, Else } = require('@cuties/if-else');
-const { IsMaster, ClusterWithForkedWorkers } = require('@cuties/cluster');
+const { ProcessWithExitEvent, KilledProcess } = require('@cuties/process');
+const { IsMaster, ClusterWithForkedWorkers, ClusterWithExitEvent } = require('@cuties/cluster');
 const { ParsedJSON, Value } = require('@cuties/json');
 const { ExecutedScripts } = require('@cuties/scripts');
 const { Backend, RestApi, CreatedServingFilesMethod, CreatedCachedServingFilesMethod } = require('@cuties/rest');
@@ -12,6 +13,7 @@ const CustomNotFoundMethod = require('./CustomNotFoundMethod');
 const CreatedCustomIndex = require('./CreatedCustomIndex');
 const OnStaticGeneratorsChangeEvent = require('./OnStaticGeneratorsChangeEvent');
 const OnTemplatesChangeEvent = require('./OnTemplatesChangeEvent');
+const ReloadedBackendOnFailedWorkerEvent = require('./ReloadedBackendOnFailedWorkerEvent');
 const UrlToFSPathMapper = require('./UrlToFSPathMapper');
 const PrintedToConsolePageLogo = require('./PrintedToConsolePageLogo');
 const notFoundMethod = new CustomNotFoundMethod(new RegExp(/^\/not-found/));
@@ -70,6 +72,11 @@ new ParsedJSON(
         new IsMaster(cluster),
         new ClusterWithForkedWorkers(
           cluster, numCPUs
+        ).after(
+          new ClusterWithExitEvent(
+            cluster, 
+            new ReloadedBackendOnFailedWorkerEvent()
+          )
         ),
         new Else(
           launchedBackend


### PR DESCRIPTION
#48 It's not possible to restart process in not cluster more, so if user want to have server that never crashes(or in another words server that reloads on failure) then clusterMode in `config.js` must be `true`